### PR TITLE
Fix Linux dependencies in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       
       # Install Tauri CLI
       - name: Install Tauri CLI


### PR DESCRIPTION
## Summary
- update Linux dependencies in the release workflow to use libwebkit2gtk-4.1-dev

## Testing
- `npm test` *(fails: Missing script)*
- `cargo test` *(fails: could not find `Cargo.toml`)*