### PR TITLE
Fix textarea jump

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1077,7 +1077,7 @@ body {
 .autosave-indicator {
   font-size: 0.8rem;
   color: var(--primary-color);
-  margin-left: 0.5rem;
+  margin-left: 0;
   font-style: italic;
   animation: pulse 1.5s infinite;
 }
@@ -1094,6 +1094,14 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
+  padding-bottom: 1.2rem;
+}
+
+.editor-status {
+  position: absolute;
+  bottom: 0.25rem;
+  right: 0.5rem;
+  font-size: 0.8rem;
 }
 
 .error-message {
@@ -1129,7 +1137,8 @@ body {
   min-height: 300px;
   height: 100%;
   position: relative;
-  overflow-y: auto;
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
   box-sizing: border-box;
   display: block;
 }
@@ -1619,7 +1628,8 @@ body {
   font-family: monospace;
   font-size: 1rem;
   line-height: 1.5;
-  overflow-y: auto; /* Enable scrollbar when needed */
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
   background-color: inherit;
   color: inherit;
   max-height: calc(100vh - 200px); /* Limit height to prevent excessive growth */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,8 @@ function App() {
     noteLoading,
     error: noteError,
     loadNote,
-    invalidateCache
+    invalidateCache,
+    updateNote
   } = useCachedNotes();
 
   // Use the navigation history hook
@@ -247,19 +248,16 @@ function App() {
       
       // Update note content
       const updatedNote = await invoke<Note>('update_note_content', { id, content });
-      
+
       // Verify that the selected ID hasn't changed during the update
       if (id === selectedNoteId) {
-        // Invalidate the cache for this note
-        invalidateCache(id);
-        
-        // Reload the note to update the cache
-        await loadNote(id);
-        
+        // Update the cached note directly to avoid reload
+        updateNote(updatedNote);
+
         // Update the note in the notes list in the background
         setTimeout(() => {
-          setNotes(prevNotes => 
-            prevNotes.map(note => 
+          setNotes(prevNotes =>
+            prevNotes.map(note =>
               note.id === id 
                 ? { 
                     ...note, 
@@ -292,14 +290,11 @@ function App() {
       // Rename the note
       const updatedNote = await invoke<Note>('rename_note', { id, newName });
       
-      // Invalidate the cache for this note
-      invalidateCache(id);
-      
       // Update the selected note ID (might have changed due to path change)
       setSelectedNoteId(updatedNote.id);
-      
-      // Reload the note to update the cache
-      await loadNote(updatedNote.id);
+
+      // Update the cached note directly
+      updateNote(updatedNote);
       
       // Update the note in the notes list
       // We'll do this in the background to avoid UI refresh during editing
@@ -327,14 +322,11 @@ function App() {
       // Move the note to the new path
       const updatedNote = await invoke<Note>('move_note', { id, newPath });
       
-      // Invalidate the cache for this note
-      invalidateCache(id);
-      
       // Update the selected note ID (might have changed due to path change)
       setSelectedNoteId(updatedNote.id);
-      
-      // Reload the note to update the cache
-      await loadNote(updatedNote.id);
+
+      // Update the cached note directly
+      updateNote(updatedNote);
       
       // Update the note in the notes list
       // We'll do this in the background to avoid UI refresh during editing

--- a/src/components/NoteViewer.tsx
+++ b/src/components/NoteViewer.tsx
@@ -984,7 +984,11 @@ export const NoteViewer: React.FC<NoteViewerProps> = ({
                 className="content-editor"
                 autoFocus
               />
-              {isSaving && <span className="autosave-indicator">Saving...</span>}
+              <div className="editor-status">
+                {isSaving && (
+                  <span className="autosave-indicator">Saving...</span>
+                )}
+              </div>
             </div>
           ) : note.file_type === NoteType.Markdown ? (
             <div className="markdown-content editable">

--- a/src/components/noteViewer/NoteContent.tsx
+++ b/src/components/noteViewer/NoteContent.tsx
@@ -415,7 +415,9 @@ export const NoteContent: React.FC<NoteContentProps> = ({
             style={editorHeight ? { height: editorHeight } : undefined}
             autoFocus
           />
-          {isSaving && <span className="autosave-indicator">Saving...</span>}
+          <div className="editor-status">
+            {isSaving && <span className="autosave-indicator">Saving...</span>}
+          </div>
         </>
       ) : note.file_type === NoteType.Markdown ? (
         <div className="markdown-content editable">

--- a/src/hooks/useCachedNotes.ts
+++ b/src/hooks/useCachedNotes.ts
@@ -148,6 +148,16 @@ export const useCachedNotes = () => {
   const clearCache = useCallback((): void => {
     noteCache.clear();
   }, []);
+
+  /**
+   * Updates the currently selected note and refreshes the cache
+   *
+   * @param note The updated note
+   */
+  const updateNote = useCallback((note: Note): void => {
+    setSelectedNote(note);
+    addToCache(note);
+  }, [addToCache]);
   
   // Clean up on unmount
   useEffect(() => {
@@ -162,6 +172,7 @@ export const useCachedNotes = () => {
     error,
     loadNote,
     invalidateCache,
-    clearCache
+    clearCache,
+    updateNote
   };
 };


### PR DESCRIPTION
## Summary
- keep scrollbars always visible for note editors
- reserve space in editor container for autosave status
- display autosave indicator in a fixed status bar

## Testing
- `node --loader ts-node/esm tests/findReplace.test.ts` *(fails: Cannot find package 'ts-node')*
- `cargo test` in `src-tauri` *(fails: failed to download crates)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840f90299708320a73a057fb54aa696