### PR TITLE
Fix TypeScript build error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,6 @@ function App() {
     noteLoading,
     error: noteError,
     loadNote,
-    invalidateCache,
     updateNote
   } = useCachedNotes();
 


### PR DESCRIPTION
## Summary
- remove `invalidateCache` from `useCachedNotes` usage in `App`

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6842208edf808320971fd5d0d89eb69b