### PR TITLE
Implement link autocomplete

### DIFF
--- a/docs/note-linking.md
+++ b/docs/note-linking.md
@@ -22,6 +22,7 @@ To create a link to another note, use the double bracket syntax:
 ```
 
 Where "Note Title" is the exact title of the note you want to link to. The link will work in both Markdown (`.md`) and plain text (`.txt`) files.
+When you type `[[` in the editor, Notter automatically inserts the closing `]]` and shows a dropdown of existing note titles to speed up linking.
 
 ### Examples
 

--- a/docs/note-linking.md
+++ b/docs/note-linking.md
@@ -89,9 +89,9 @@ For the most effective use of note linking:
 
 ## Future Enhancements
 
-Planned enhancements for the note linking feature include:
+- Future enhancements for the note linking feature include:
 
-- Autocomplete when typing `[[` to suggest existing note titles
+- ~~Autocomplete when typing `[[` to suggest existing note titles~~ *(implemented)*
 - Visual graph of note connections
 - Link preview on hover
 - Support for linking to specific sections within notes

--- a/docs/note-linking.md
+++ b/docs/note-linking.md
@@ -22,7 +22,7 @@ To create a link to another note, use the double bracket syntax:
 ```
 
 Where "Note Title" is the exact title of the note you want to link to. The link will work in both Markdown (`.md`) and plain text (`.txt`) files.
-When you type `[[` in the editor, Notter automatically inserts the closing `]]` and shows a dropdown of existing note titles to speed up linking.
+When you type `[[` in the editor, Notter automatically inserts the closing `]]` and shows a dropdown of existing note titles to speed up linking. Use the arrow keys or your mouse to select a suggestion, and the chosen title will be inserted between the brackets.
 
 ### Examples
 

--- a/src/components/NoteViewer.refactored.tsx
+++ b/src/components/NoteViewer.refactored.tsx
@@ -247,6 +247,7 @@ export const NoteViewer: React.FC<NoteViewerProps> = ({
           onContentDoubleClick={handleContentDoubleClick}
           onNoteLinkClick={handleNoteLinkClick}
           onExternalLinkClick={handleExternalLinkClick}
+          setEditedContent={setEditedContent}
         />
         
         {/* Backlinks Section */}

--- a/src/components/OptimizedNoteViewer.tsx
+++ b/src/components/OptimizedNoteViewer.tsx
@@ -292,6 +292,7 @@ export const OptimizedNoteViewer: React.FC<OptimizedNoteViewerProps> = ({
           textareaRef={textareaRef}
           onNoteLinkClick={handleNoteLinkClick}
           onExternalLinkClick={handleExternalLinkClick}
+          setEditedContent={setEditedContent}
         />
         
         {/* Backlinks Section - lazy loaded with a delay */}

--- a/src/components/noteViewer/NoteContent.tsx
+++ b/src/components/noteViewer/NoteContent.tsx
@@ -201,7 +201,8 @@ export const NoteContent: React.FC<NoteContentProps> = ({
         e.preventDefault();
         const before = editedContent.substring(0, selectionStart);
         const after = editedContent.substring(selectionStart);
-        const newContent = `${before}[[]]${after}`;
+        // Insert the typed "[" followed by the closing brackets
+        const newContent = `${before}[]]${after}`;
         setEditedContent(newContent);
         const newPos = selectionStart + 1;
         setShowAutocomplete(true);

--- a/src/components/noteViewer/NoteContent.tsx
+++ b/src/components/noteViewer/NoteContent.tsx
@@ -191,6 +191,34 @@ export const NoteContent: React.FC<NoteContentProps> = ({
   
   // Custom key down handler to preserve scroll position
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === '[' && textareaRef?.current) {
+      const { selectionStart, selectionEnd } = textareaRef.current;
+      if (
+        selectionStart === selectionEnd &&
+        selectionStart > 0 &&
+        editedContent[selectionStart - 1] === '['
+      ) {
+        e.preventDefault();
+        const before = editedContent.substring(0, selectionStart);
+        const after = editedContent.substring(selectionStart);
+        const newContent = `${before}[[]]${after}`;
+        setEditedContent(newContent);
+        const newPos = selectionStart + 1;
+        setShowAutocomplete(true);
+        setAutocompleteStart(newPos);
+        setAutocompleteQuery('');
+        setSelectedIndex(0);
+        if (textareaRef.current) {
+          setDropdownPos(getCaretCoordinates(textareaRef.current, newPos));
+        }
+        setTimeout(() => {
+          textareaRef.current?.focus();
+          textareaRef.current?.setSelectionRange(newPos, newPos);
+        }, 0);
+        return;
+      }
+    }
+
     if (showAutocomplete) {
       if (e.key === 'ArrowDown') {
         e.preventDefault();

--- a/src/components/noteViewer/NoteLinkAutocomplete.css
+++ b/src/components/noteViewer/NoteLinkAutocomplete.css
@@ -1,0 +1,24 @@
+.note-link-autocomplete {
+  position: absolute;
+  z-index: 1000;
+  background: white;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.note-link-autocomplete li {
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.note-link-autocomplete li.selected,
+.note-link-autocomplete li:hover {
+  background: var(--hover-color);
+  color: white;
+}

--- a/src/components/noteViewer/NoteLinkAutocomplete.tsx
+++ b/src/components/noteViewer/NoteLinkAutocomplete.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { SearchResult } from '../../types';
+import './NoteLinkAutocomplete.css';
+
+interface NoteLinkAutocompleteProps {
+  position: { top: number; left: number };
+  suggestions: SearchResult[];
+  selectedIndex: number;
+  onSelect: (title: string) => void;
+}
+
+export const NoteLinkAutocomplete: React.FC<NoteLinkAutocompleteProps> = ({
+  position,
+  suggestions,
+  selectedIndex,
+  onSelect
+}) => {
+  if (suggestions.length === 0) return null;
+
+  return (
+    <ul
+      className="note-link-autocomplete"
+      style={{ top: position.top, left: position.left }}
+    >
+      {suggestions.map((result, index) => (
+        <li
+          key={result.note.id}
+          className={index === selectedIndex ? 'selected' : undefined}
+          onMouseDown={() => onSelect(result.note.title)}
+        >
+          {result.note.title}
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/components/noteViewer/index.ts
+++ b/src/components/noteViewer/index.ts
@@ -5,3 +5,4 @@
 export { NoteHeader } from './NoteHeader';
 export { NoteContent } from './NoteContent';
 export { BacklinksSection } from './BacklinksSection';
+export { NoteLinkAutocomplete } from './NoteLinkAutocomplete';


### PR DESCRIPTION
## Summary
- add NoteLinkAutocomplete component
- integrate link suggestions into NoteContent
- update docs to reflect autocomplete implementation

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68438206da6c8320a3ae3e1e686f67af