### PR TITLE
Fix subnote id pattern

### DIFF
--- a/docs/zettelkasten-subnotes.md
+++ b/docs/zettelkasten-subnotes.md
@@ -103,6 +103,10 @@ The system follows the traditional Zettelkasten numbering pattern:
    1a1b-property-dualism.md
    ```
 
+When creating a subnote with the "Add Subnote" button, the new file uses your
+specified prefix directly (for example `1a1-new-topic.md`) and does not add an
+extra numeric prefix.
+
 ### Viewing Subnotes
 
 1. **Open a parent note**: Click on any note in the note list

--- a/src/components/AddSubnoteButton.tsx
+++ b/src/components/AddSubnoteButton.tsx
@@ -210,8 +210,9 @@ export const AddSubnoteButton: React.FC<AddSubnoteButtonProps> = ({
       // Create the full title with suggested ID
       const fullTitle = `${suggestedId}-${title.trim()}`;
       
-      // Use the naming pattern from config or default
-      const pattern = config?.note_naming_pattern || "{number}-{title}.{extension}";
+      // Subnotes should not include an auto-incremented number prefix.
+      // Always generate the filename directly from the provided title.
+      const pattern = "{title}.{extension}";
       
       // Create the subnote
       const newNote = await invoke<Note>('create_note', {


### PR DESCRIPTION
## Summary
- remove number prefix when creating a subnote
- document that Add Subnote uses the prefix directly

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684445d007f88320a7e72cd78b14b67e